### PR TITLE
Pass client id via build arg [IST-191]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM node:current-alpine as builder
 WORKDIR /app
 COPY . .
+
+ARG CLIENT_ID
+RUN sed -i -e 's/CLIENT_ID/'"$CLIENT_ID"'/' "src/auth/msalApp.ts"
+
 RUN yarn install; \
- yarn run build
+    yarn run build
 
 FROM nginx:stable-alpine
 COPY --from=builder /app/build /usr/share/nginx/html

--- a/src/auth/msalApp.ts
+++ b/src/auth/msalApp.ts
@@ -13,7 +13,7 @@ function isIE() {
 
 export const msalApp = new UserAgentApplication({
   auth: {
-    clientId: 'b80d7625-77ad-4024-a3a0-16796675aa57', // TODO: move this into a cfg value from composition root
+    clientId: 'CLIENT_ID', // TODO: move this into a cfg value from composition root
     authority: 'https://login.microsoftonline.com/common',
     validateAuthority: true,
     postLogoutRedirectUri: 'http://localhost:3000',


### PR DESCRIPTION
To build add the client id during the build, you may execute this

```
docker build -t msteams --build-arg CLIENT_ID=CLIENT_ID_VALUE  . 
```